### PR TITLE
Capital Env names and GCS fix

### DIFF
--- a/client/node/config.go
+++ b/client/node/config.go
@@ -9,10 +9,10 @@ import (
 
 // Config holds configurable properties for node client
 type Config struct {
-	Blockchain constants.Blockchain `env:"blockchain,required"`
-	NodeHost   string               `env:"node_host,required"`
-	RPCTimeout time.Duration        `env:"rpc_timeout" envDefault:"300s"`
-	RPCRetries int                  `env:"rpc_retries" envDefault:"2"`
+	Blockchain constants.Blockchain `env:"BLOCKCHAIN,required"`
+	NodeHost   string               `env:"NODE_HOST,required"`
+	RPCTimeout time.Duration        `env:"RPC_TIMEOUT" envDefault:"300s"`
+	RPCRetries int                  `env:"RPC_RETRIES" envDefault:"2"`
 }
 
 // ParseConfig parses config from env vars

--- a/drivers/ethereum/config.go
+++ b/drivers/ethereum/config.go
@@ -7,8 +7,8 @@ import (
 
 // Config stores configurable properties of the driver
 type Config struct {
-	MaxRetries     int    `env:"http_max_retries" envDefault:"10"`
-	DirectoryRange uint64 `env:"bucket_directory_range" envDefault:"10000"`
+	MaxRetries     int    `env:"HTTP_MAX_RETRIES" envDefault:"10"`
+	DirectoryRange uint64 `env:"BUCKET_DIRECTORY_RANGE" envDefault:"10000"`
 }
 
 // MustParseConfig uses env.Parse to initialize config with environment variables

--- a/shared/storage/gcs.go
+++ b/shared/storage/gcs.go
@@ -22,9 +22,9 @@ type GCSConnector struct {
 }
 
 type GCSConfig struct {
-	BucketName string `env:"gcs_bucket_name,required"`
-	ProjectID  string `env:"gcp_project_id,required"`
-	RangeSize  uint64 `env:"gcs_dir_range_size" envDefault:"10000"`
+	BucketName string `env:"GCS_BUCKET_NAME,required"`
+	ProjectID  string `env:"GCP_PROJECT_ID,required"`
+	RangeSize  uint64 `env:"GCS_DIR_RANGE_SIZE" envDefault:"10000"`
 }
 
 func NewGCSConnector(ctx context.Context, cfg *GCSConfig) (*GCSConnector, error) {
@@ -55,7 +55,16 @@ func (g *GCSConnector) WriteOne(ctx context.Context, input interface{}, mapToStr
 	if err != nil {
 		return errors.Errorf("cannot open file: %v", err)
 	}
-	defer gw.Close()
+	defer func() {
+		closeErr := gw.Close()
+		if closeErr != nil {
+			if err != nil {
+				err = errors.Wrapf(err, "GcsFileWriter Close error: %v", closeErr)
+			} else {
+				err = errors.Errorf("GcsFileWriter Close error: %v", closeErr)
+			}
+		}
+	}()
 
 	pw, err := writer.NewParquetWriter(gw, mapToStruct, 4)
 	if err != nil {
@@ -84,7 +93,16 @@ func (g *GCSConnector) WriteMany(ctx context.Context, input []interface{}, mapTo
 	if err != nil {
 		return errors.Errorf("cannot open file: %v", err)
 	}
-	defer gw.Close()
+	defer func() {
+		closeErr := gw.Close()
+		if closeErr != nil {
+			if err != nil {
+				err = errors.Wrapf(err, "GcsFileWriter Close error: %v", closeErr)
+			} else {
+				err = errors.Errorf("GcsFileWriter Close error: %v", closeErr)
+			}
+		}
+	}()
 
 	pw, err := writer.NewParquetWriter(gw, mapToStruct, 4)
 	if err != nil {

--- a/shared/storage/gcs.go
+++ b/shared/storage/gcs.go
@@ -46,6 +46,7 @@ func MustNewGCSConnector(ctx context.Context, cfg *GCSConfig, logger framework.L
 
 // Write writes a single parquet to GCS storage
 func (g *GCSConnector) WriteOne(ctx context.Context, input interface{}, mapToStruct interface{}, filename string) error {
+	var err error
 	gw, err := gcs.NewGcsFileWriter(
 		ctx,
 		g.projectID,
@@ -84,6 +85,7 @@ func (g *GCSConnector) WriteOne(ctx context.Context, input interface{}, mapToStr
 
 // Write writes a mutliple parquets to GCS storage
 func (g *GCSConnector) WriteMany(ctx context.Context, input []interface{}, mapToStruct interface{}, filename string) error {
+	var err error
 	gw, err := gcs.NewGcsFileWriter(
 		ctx,
 		g.projectID,


### PR DESCRIPTION
Capitalizing Env names

Also, a fix that does a better job of isolating possible errors with `gcs.Close()` that can happen when parquet write succeeds (and the function returns successfully) but there is an upload issue that fails after the fact (race condition between GCS and parquet writer).