### PR TITLE
[fix] fixing receipt fetching logic for base to handle multiple txns per block

### DIFF
--- a/drivers/base/accumulate.go
+++ b/drivers/base/accumulate.go
@@ -44,7 +44,7 @@ func extractBlockAndReceipts(set pool.ResultSet) (*protos.Block, []*protos.Trans
 		return nil, nil, errors.New("incorrect data type for block/receipt wrapper")
 	}
 
-	return wrapper.block, []*protos.TransactionReceipt{wrapper.receipt}, nil
+	return wrapper.block, wrapper.receipts, nil
 }
 
 // extractTraces extracts traces from the generic ResultSet from the fetch step

--- a/drivers/base/write.go
+++ b/drivers/base/write.go
@@ -106,7 +106,6 @@ func (d *Driver) parquetAndUploadLogs(res interface{}) pool.Runner {
 		var outputs []interface{}
 		for _, receipt := range block.TransactionReceipts {
 			for _, log := range receipt.Logs {
-				d.logger.Infof("log: %v", log)
 				outputs = append(outputs, ProtoLogToParquet(log))
 			}
 		}


### PR DESCRIPTION
Currently, we were only fetching one receipt per block. There are multiple txns within a block for Base.