### PR TITLE
[fix] adding length check for transaction receipts for binance

### DIFF
--- a/drivers/binance/write.go
+++ b/drivers/binance/write.go
@@ -65,12 +65,17 @@ func (d *Driver) parquetAndUploadTransactions(res interface{}) pool.Runner {
 		}
 
 		var outputs []interface{}
-		for i, tx := range block.Block.Transactions {
-			parquetTransaction, err := ProtoTransactionToParquet(tx, block.TransactionReceipts[i])
-			if err != nil {
-				return nil, err
+		if len(block.TransactionReceipts) != len(block.TransactionReceipts) {
+			return nil, errors.New(fmt.Sprintf("block %d has %d transactions but %d receipts", blockNumber, len(block.Block.Transactions), len(block.TransactionReceipts)))
+		}
+		for i := range block.Block.Transactions {
+			if i < len(block.TransactionReceipts) {
+				parquetTransaction, err := ProtoTransactionToParquet(block.Block.Transactions[i], block.TransactionReceipts[i])
+				if err != nil {
+					return nil, err
+				}
+				outputs = append(outputs, parquetTransaction)
 			}
-			outputs = append(outputs, parquetTransaction)
 		}
 
 		filename := fmt.Sprintf("transactions/%s/%d.parquet", util.RangeName(blockNumber, d.config.DirectoryRange), blockNumber)


### PR DESCRIPTION
- to avoid panicking when the length of receipts is not the same as transactions