### PR TITLE
[new chain] arbitrum driver

### DIFF
--- a/drivers/arbitrum/accumulate.go
+++ b/drivers/arbitrum/accumulate.go
@@ -1,0 +1,62 @@
+package arbitrum
+
+import (
+	"context"
+	"errors"
+	protos "github.com/coherentopensource/chain-interactor/protos/go/protos/chains/arbitrum"
+	"github.com/coherentopensource/go-service-framework/pool"
+)
+
+// Accumulate combines a block, receipts, and traces from multiple protos into a single object, given a generic
+// result from the "fetch" step
+func (d *Driver) Accumulate(res interface{}) pool.Runner {
+	return func(ctx context.Context) (interface{}, error) {
+		set, ok := res.(pool.ResultSet)
+		if !ok {
+			return nil, errors.New("result is not expected type")
+		}
+
+		block, receipts, err := extractBlockAndReceipts(set)
+		if err != nil {
+			return nil, err
+		}
+		traces, err := extractTraces(set)
+		if err != nil {
+			return nil, err
+		}
+
+		return &protos.Data{
+			Block:               block,
+			TransactionReceipts: receipts,
+			CallTraces:          traces,
+		}, nil
+	}
+}
+
+// extractBlock extracts a block from the generic ResultSet from the fetch step
+func extractBlockAndReceipts(set pool.ResultSet) (*protos.Block, []*protos.TransactionReceipt, error) {
+	blockRes, ok := set[stageFetchBlock]
+	if !ok {
+		return nil, nil, errors.New("No block data")
+	}
+	wrapper, ok := blockRes.(*blockAndReceiptWrapper)
+	if !ok {
+		return nil, nil, errors.New("incorrect data type for block/receipt wrapper")
+	}
+
+	return wrapper.block, wrapper.receipts, nil
+}
+
+// extractTraces extracts traces from the generic ResultSet from the fetch step
+func extractTraces(set pool.ResultSet) ([]*protos.CallTrace, error) {
+	tracesRes, ok := set[stageFetchTraces]
+	if !ok {
+		return nil, errors.New("no traces data")
+	}
+	traces, ok := tracesRes.([]*protos.CallTrace)
+	if !ok {
+		return nil, errors.New("incorrect data type for traces")
+	}
+
+	return traces, nil
+}

--- a/drivers/arbitrum/client.go
+++ b/drivers/arbitrum/client.go
@@ -1,0 +1,90 @@
+package arbitrum
+
+import (
+	"context"
+	"fmt"
+	"github.com/coherentopensource/chain-interactor/client/node"
+	protos "github.com/coherentopensource/chain-interactor/protos/go/protos/chains/arbitrum"
+	"github.com/coherentopensource/go-service-framework/util"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const (
+	traceKnownError = "TypeError: cannot read property 'toString' of undefined    in server-side tracer function 'result'"
+)
+
+type client struct {
+	innerClient node.Client
+	logger      util.Logger
+}
+
+// EthBlockNumber gets the most recent block number
+func (c *client) GetLatestBlockNumber(ctx context.Context) (uint64, error) {
+	number, err := c.innerClient.GetLatestBlockNumber(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return number, nil
+}
+
+// GetBlockByNumber gets a block by number
+func (c *client) GetBlockByNumber(ctx context.Context, blockNumber uint64) (*protos.Block, error) {
+	res, err := c.innerClient.GetBlockByNumber(ctx, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	data := &protos.Block{}
+	if err := protojson.Unmarshal(res.Result, data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (c *client) GetTracesForBlock(ctx context.Context, blockNumber uint64) ([]*protos.CallTrace, error) {
+	// genesis block has no traces
+	if blockNumber == 0 {
+		return nil, nil
+	}
+
+	res, err := c.innerClient.GetTracesForBlock(ctx, blockNumber)
+	if err != nil {
+
+		//	Special case where known error should fail gracefully
+		if err.Error() == traceKnownError {
+			c.logger.Warnf("Known trace error encountered; defaulting to empty traces response: %v", err)
+			return []*protos.CallTrace{}, nil
+		}
+
+		return nil, err
+	}
+
+	var rawTraces []*protos.CallTrace
+	for _, trace := range res.Result {
+		if trace.Error != nil {
+			return nil, fmt.Errorf("%v", trace.Error)
+		}
+		rawTrace := &protos.CallTrace{}
+		if err := protojson.Unmarshal(trace.Result, rawTrace); err != nil {
+			return nil, err
+		}
+		rawTraces = append(rawTraces, rawTrace)
+	}
+
+	return rawTraces, nil
+}
+
+func (c *client) GetTransactionReceipt(ctx context.Context, txHash string) (*protos.TransactionReceipt, error) {
+	res, err := c.innerClient.GetTransactionReceipt(ctx, txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	rawReceipt := &protos.TransactionReceipt{}
+	if err := protojson.Unmarshal(res.Result, rawReceipt); err != nil {
+		return nil, err
+	}
+
+	return rawReceipt, nil
+}

--- a/drivers/arbitrum/codec.go
+++ b/drivers/arbitrum/codec.go
@@ -1,0 +1,131 @@
+package arbitrum
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	protos "github.com/coherentopensource/chain-interactor/protos/go/protos/chains/arbitrum"
+	model "github.com/coherentopensource/evm-etl/model/arbitrum"
+)
+
+// ProtoBlockToParquet converts a block proto to parquet
+func ProtoBlockToParquet(in *protos.Block) *model.ParquetBlock {
+	out := model.ParquetBlock{
+		Number:           in.Number,
+		Hash:             in.Hash,
+		ParentHash:       in.ParentHash,
+		Nonce:            in.Nonce,
+		SHA3Uncles:       in.Sha3Uncles,
+		LogsBloom:        in.LogsBloom,
+		TransactionsRoot: in.TransactionsRoot,
+		StateRoot:        in.StateRoot,
+		ReceiptsRoot:     in.ReceiptsRoot,
+		Miner:            in.Miner,
+		Difficulty:       in.Difficulty,
+		TotalDifficulty:  in.TotalDifficulty,
+		ExtraData:        in.ExtraData,
+		Size:             in.Size,
+		GasLimit:         in.GasLimit,
+		GasUsed:          in.GasUsed,
+		Timestamp:        in.Timestamp,
+		MixHash:          in.MixHash,
+	}
+
+	for _, uncle := range in.Uncles {
+		out.Uncles = append(out.Uncles, uncle)
+	}
+
+	return &out
+}
+
+// ProtoTransactionToParquet converts a transaction proto to parquet, given a transaction and receipt
+func ProtoTransactionToParquet(inTx *protos.Transaction, inReceipt *protos.TransactionReceipt) (*model.ParquetTransaction, error) {
+	out := model.ParquetTransaction{
+		BlockNumber:       inTx.BlockNumber,
+		BlockHash:         inTx.BlockHash,
+		Hash:              inTx.Hash,
+		From:              inTx.From,
+		To:                inTx.To,
+		Value:             inTx.Value,
+		Gas:               inTx.Gas,
+		GasPrice:          inTx.GasPrice,
+		Input:             inTx.Input,
+		Nonce:             inTx.Nonce,
+		TransactionIndex:  inTx.TransactionIndex,
+		V:                 inTx.V,
+		R:                 inTx.R,
+		S:                 inTx.S,
+		CumulativeGasUsed: inReceipt.CumulativeGasUsed,
+		GasUsed:           inReceipt.GasUsed,
+		LogsBloom:         inReceipt.LogsBloom,
+		Status:            inReceipt.Status,
+		L1Fee:             inReceipt.L1Fee,
+		L1FeeScalar:       inReceipt.L1FeeScalar,
+		L1GasPrice:        inReceipt.L1GasPrice,
+		L1GasUsed:         inReceipt.L1GasUsed,
+	}
+
+	return &out, nil
+}
+
+// ProtoLogToParquet converts a log proto to parquet
+func ProtoLogToParquet(in *protos.Log) *model.ParquetLog {
+	out := model.ParquetLog{
+		BlockNumber:      in.BlockNumber,
+		BlockHash:        in.BlockHash,
+		TransactionHash:  in.TransactionHash,
+		TransactionIndex: in.TransactionIndex,
+		LogIndex:         in.LogIndex,
+		Address:          in.Address,
+		Data:             in.Data,
+		Removed:          in.Removed,
+	}
+	for _, topic := range in.Topics {
+		out.Topics = append(out.Topics, topic)
+	}
+
+	return &out
+}
+
+// ProtoTraceToParquet converts a trace proto to parquet, given a trace, a transaction, and other supplemental data
+func ProtoTraceToParquet(inTrace *protos.CallTrace, inTransaction *protos.Transaction, hash string, parentHash string, index int64) *model.ParquetTrace {
+	return &model.ParquetTrace{
+		BlockNumber:     inTransaction.BlockNumber,
+		BlockHash:       inTransaction.BlockHash,
+		TransactionHash: inTransaction.Hash,
+		Hash:            hash,
+		ParentHash:      parentHash,
+		Index:           index,
+		Type:            inTrace.Result.Type,
+		From:            inTrace.Result.From,
+		To:              inTrace.Result.To,
+		Value:           inTrace.Result.Value,
+		Gas:             inTrace.Result.Gas,
+		GasUsed:         inTrace.Result.GasUsed,
+		Input:           inTrace.Result.Input,
+		Output:          inTrace.Result.Output,
+	}
+}
+
+func ProtoEVMTransferToParquet(in *protos.Transfer, inTransaction *protos.Transaction, hash string, sequence string, transactionIndex int64, index int64) *model.ParquetEVMTransfer {
+	return &model.ParquetEVMTransfer{
+		BlockNumber:      inTransaction.BlockNumber,
+		BlockHash:        inTransaction.BlockHash,
+		TransactionHash:  inTransaction.Hash,
+		TraceHash:        hash,
+		From:             in.From,
+		To:               in.To,
+		Value:            in.Value,
+		Sequence:         sequence,
+		TransactionIndex: transactionIndex,
+		Index:            index,
+	}
+}
+
+// hashCallTrace hashes a trace proto
+func hashCallTrace(callTrace *protos.CallTrace) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(fmt.Sprintf("%v", callTrace)))
+
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/drivers/arbitrum/config.go
+++ b/drivers/arbitrum/config.go
@@ -1,0 +1,22 @@
+package arbitrum
+
+import (
+	"github.com/caarlos0/env/v7"
+	"github.com/coherentopensource/go-service-framework/util"
+)
+
+// Config stores configurable properties of the driver
+type Config struct {
+	MaxRetries     int    `env:"HTTP_MAX_RETRIES" envDefault:"10"`
+	DirectoryRange uint64 `env:"BUCKET_DIRECTORY_RANGE" envDefault:"10000"`
+}
+
+// MustParseConfig uses env.Parse to initialize config with environment variables
+func MustParseConfig(logger util.Logger) *Config {
+	var cfg Config
+	if err := env.Parse(&cfg); err != nil {
+		logger.Fatalf("Could not parse Arbitrum driver config: %v", err)
+	}
+
+	return &cfg
+}

--- a/drivers/arbitrum/driver.go
+++ b/drivers/arbitrum/driver.go
@@ -1,0 +1,36 @@
+package arbitrum
+
+import (
+	nodeClient "github.com/coherentopensource/chain-interactor/client/node"
+	"github.com/coherentopensource/evm-etl/shared/storage"
+	"github.com/coherentopensource/go-service-framework/constants"
+	"github.com/coherentopensource/go-service-framework/util"
+)
+
+const (
+	stageFetchBlock  = "fetch.block"
+	stageFetchTraces = "fetch.traces"
+)
+
+// Driver is the container for all ETL business logic
+type Driver struct {
+	store      *store
+	nodeClient *client
+	logger     util.Logger
+	config     *Config
+}
+
+// New constructs a new Driver
+func New(cfg *Config, nodeClient nodeClient.Client, innerStore storage.Store, logger util.Logger) *Driver {
+	return &Driver{
+		nodeClient: &client{innerClient: nodeClient, logger: logger},
+		store:      &store{innerStore: innerStore},
+		logger:     logger,
+		config:     cfg,
+	}
+}
+
+// Blockchain returns the name of the blockchain
+func (d *Driver) Blockchain() string {
+	return string(constants.Arbitrum)
+}

--- a/drivers/arbitrum/fetch.go
+++ b/drivers/arbitrum/fetch.go
@@ -1,0 +1,142 @@
+package arbitrum
+
+import (
+	"context"
+	"fmt"
+	protos "github.com/coherentopensource/chain-interactor/protos/go/protos/chains/arbitrum"
+	"github.com/coherentopensource/go-service-framework/pool"
+	"github.com/coherentopensource/go-service-framework/retry"
+	"sync"
+)
+
+type blockAndReceiptWrapper struct {
+	block    *protos.Block
+	receipts []*protos.TransactionReceipt
+}
+
+// FetchSequence defines the parallelizable steps in the fetch sequence
+func (d *Driver) FetchSequence(blockHeight uint64) map[string]pool.Runner {
+	return map[string]pool.Runner{
+		stageFetchBlock:  d.queueGetBlockAndTxReceiptByNumber(blockHeight),
+		stageFetchTraces: d.queueGetBlockTraceByNumber(blockHeight),
+	}
+}
+
+// GetChainTipNumber gets the block number of the chaintip
+func (d *Driver) GetChainTipNumber(ctx context.Context) (uint64, error) {
+	var blockNum uint64
+	var err error
+	if err := retry.Exec(d.config.MaxRetries, func() error {
+		blockNum, err = d.nodeClient.GetLatestBlockNumber(ctx)
+		if err != nil {
+			d.logger.Warnf("error thrown while trying to retrieve latest block number: %v", err)
+			return err
+		}
+		return nil
+	}, nil); err != nil {
+		d.logger.Errorf("max retries exceeded trying to get chaintip number: %v", err)
+		return 0, err
+	}
+
+	return blockNum, nil
+}
+
+// getBlockByNumber fetches a full block by number
+func (d *Driver) getBlockByNumber(ctx context.Context, blockHeight uint64) (*protos.Block, error) {
+	var block *protos.Block
+	var err error
+	if err := retry.Exec(d.config.MaxRetries, func() error {
+		block, err = d.nodeClient.GetBlockByNumber(ctx, blockHeight)
+		if err != nil {
+			d.logger.Warnf("error thrown while trying to retrieve block: %d, %v", blockHeight, err)
+			return err
+		}
+
+		return nil
+	}, nil); err != nil {
+		d.logger.Errorf("max retries exceeded trying to get block by number: %v", err)
+		return nil, err
+	}
+
+	return block, nil
+}
+
+// getBlockAndTransactionReceipt fetches a full block by number, along with the transaction receipt for its first transaction
+func (d *Driver) getTransactionReceipt(ctx context.Context, txHash string) (*protos.TransactionReceipt, error) {
+	var txReceipt *protos.TransactionReceipt
+	var err error
+
+	if err := retry.Exec(d.config.MaxRetries, func() error {
+		txReceipt, err = d.nodeClient.GetTransactionReceipt(ctx, txHash)
+		if err != nil {
+			d.logger.Warnf("error thrown while trying to retrieve transaction receipt: %d, %v", txHash, err)
+			return err
+		}
+		return nil
+	}, nil); err != nil {
+		d.logger.Errorf("max retries exceeded trying to get block by number: %v", err)
+		return nil, err
+	}
+
+	return txReceipt, nil
+}
+
+// getBlockTraceByNumber fetches all traces for a given block
+func (d *Driver) getBlockTraceByNumber(ctx context.Context, blockHeight uint64) ([]*protos.CallTrace, error) {
+	var traces []*protos.CallTrace
+	var err error
+	if err := retry.Exec(d.config.MaxRetries, func() error {
+		traces, err = d.nodeClient.GetTracesForBlock(ctx, blockHeight)
+		if err != nil {
+			d.logger.Warnf("error thrown while trying to retrieve block trace: %d, %v", blockHeight, err)
+			return err
+		}
+
+		return nil
+	}, nil); err != nil {
+		d.logger.Errorf("max retries exceeded trying to get traces: %v", err)
+		return nil, err
+	}
+
+	return traces, nil
+}
+
+// queueGetBlockTraceByNumber wraps GetBlockTraceByNumber in a queueable Runner func
+func (d *Driver) queueGetBlockTraceByNumber(blockHeight uint64) pool.Runner {
+	return func(ctx context.Context) (interface{}, error) {
+		return d.getBlockTraceByNumber(ctx, blockHeight)
+	}
+}
+
+// queueGetBlockAndTxReceiptByNumber wraps ReadBlockByNumber in a queueable Runner func
+func (d *Driver) queueGetBlockAndTxReceiptByNumber(blockHeight uint64) pool.Runner {
+	return func(ctx context.Context) (interface{}, error) {
+		block, err := d.getBlockByNumber(ctx, blockHeight)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(block.Transactions) == 0 {
+			return nil, fmt.Errorf("no transactions present in block %d", blockHeight)
+		}
+
+		receipts := make([]*protos.TransactionReceipt, len(block.Transactions))
+
+		var wg sync.WaitGroup
+		wg.Add(len(block.Transactions))
+		for index, transaction := range block.Transactions {
+			go func(ctx context.Context, i int, tx *protos.Transaction) {
+				defer wg.Done()
+				txReceipt, err := d.getTransactionReceipt(ctx, tx.Hash)
+				if err != nil {
+					d.logger.Errorf("error fetching transaction receipt with hash: %s, %v", tx.Hash, err)
+				}
+				receipts[i] = txReceipt
+			}(ctx, index, transaction)
+
+		}
+		wg.Wait()
+
+		return &blockAndReceiptWrapper{block: block, receipts: receipts}, nil
+	}
+}

--- a/drivers/arbitrum/store.go
+++ b/drivers/arbitrum/store.go
@@ -1,0 +1,43 @@
+package arbitrum
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	model "github.com/coherentopensource/evm-etl/model/arbitrum"
+	"github.com/coherentopensource/evm-etl/shared/storage"
+	"github.com/coherentopensource/evm-etl/shared/util"
+	"github.com/xitongsys/parquet-go-source/gcs"
+	"github.com/xitongsys/parquet-go/reader"
+)
+
+type store struct {
+	innerStore storage.Store
+}
+
+func (s *store) RetrieveBlock(ctx context.Context, blockHeight uint64) (*model.ParquetBlock, error) {
+	filename := fmt.Sprintf("blocks/%s/%d.parquet", util.RangeName(blockHeight, s.innerStore.RangeSize()), blockHeight)
+	fr, err := gcs.NewGcsFileReader(ctx, s.innerStore.ProjectID(), s.innerStore.Bucket(), filename)
+	if err != nil {
+		return nil, err
+	}
+	defer fr.Close()
+
+	pr, err := reader.NewParquetReader(fr, new(model.ParquetBlock), 4)
+	if err != nil {
+		return nil, err
+	}
+	defer pr.ReadStop()
+
+	//	We expect 1 row - make sure there is at least 1 and take the first 1
+	if pr.GetNumRows() == 0 {
+		return nil, errors.New("No rows in block parquet")
+	}
+
+	block := make([]model.ParquetBlock, 1)
+	if err = pr.Read(&block); err != nil {
+		return nil, err
+	}
+
+	return &block[0], nil
+}

--- a/drivers/arbitrum/validate.go
+++ b/drivers/arbitrum/validate.go
@@ -1,0 +1,27 @@
+package arbitrum
+
+import (
+	"context"
+	"errors"
+)
+
+// IsValidBlock checks the given block's parent hash against the hash of the previous block
+func (d *Driver) IsValidBlock(ctx context.Context, index uint64) error {
+	d.logger.Infof("Comparing block %d to block %d for validation", index, index-1)
+
+	currentBlock, err := d.getBlockByNumber(ctx, index)
+	if err != nil {
+		return err
+	}
+	previousBlock, err := d.store.RetrieveBlock(ctx, index-1)
+	if err != nil {
+		return err
+	}
+
+	if currentBlock.ParentHash != previousBlock.Hash {
+		d.logger.Infof("chain reorg detected at block %d", previousBlock.Number)
+		return errors.New("New block parent hash does not match previous block hash")
+	}
+
+	return nil
+}

--- a/drivers/arbitrum/write.go
+++ b/drivers/arbitrum/write.go
@@ -1,0 +1,259 @@
+package arbitrum
+
+import (
+	"context"
+	"fmt"
+	protos "github.com/coherentopensource/chain-interactor/protos/go/protos/chains/arbitrum"
+	model "github.com/coherentopensource/evm-etl/model/arbitrum"
+	"github.com/coherentopensource/evm-etl/shared/util"
+	"github.com/coherentopensource/go-service-framework/pool"
+	"github.com/pkg/errors"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	nullAddress = "0x0000000000000000000000000000000000000000"
+)
+
+// callTraceNode is a local utility struct for performing BFS-style traversal of trace tree
+type callTraceNode struct {
+	CallTrace  *protos.CallTrace
+	Index      int64
+	ParentHash string
+}
+
+// Writers defines a set of parallelizable write steps for processing a block and its children
+func (d *Driver) Writers() []pool.FeedTransformer {
+	return []pool.FeedTransformer{
+		d.parquetAndUploadBlock,
+		d.parquetAndUploadTransactions,
+		d.parquetAndUploadTraces,
+		d.parquetAndUploadLogs,
+	}
+}
+
+// parquetAndUploadBlock writes parquet to storage for a block
+func (d *Driver) parquetAndUploadBlock(res interface{}) pool.Runner {
+	return func(ctx context.Context) (interface{}, error) {
+		block, blockNumber, err := unpackBlock(res)
+		if err != nil {
+			return nil, err
+		}
+
+		filename := fmt.Sprintf("blocks/%s/%d.parquet", util.RangeName(blockNumber, d.config.DirectoryRange), blockNumber)
+		if err := d.store.innerStore.WriteOne(ctx, ProtoBlockToParquet(block.Block), &model.ParquetBlock{}, filename); err != nil {
+			return nil, err
+		}
+
+		d.logger.Infof("successfully parqueted block for %d", blockNumber)
+		return nil, nil
+	}
+}
+
+// parquetAndUploadTransactions writes parquet to storage for transactions
+func (d *Driver) parquetAndUploadTransactions(res interface{}) pool.Runner {
+	return func(ctx context.Context) (interface{}, error) {
+		block, blockNumber, err := unpackBlock(res)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(block.Block.Transactions) == 0 {
+			return nil, nil
+		}
+
+		var outputs []interface{}
+
+		if len(block.TransactionReceipts) != len(block.TransactionReceipts) {
+			return nil, errors.New(fmt.Sprintf("block %d has %d transactions but %d receipts", blockNumber, len(block.Block.Transactions), len(block.TransactionReceipts)))
+		}
+
+		for i := range block.Block.Transactions {
+			if i < len(block.TransactionReceipts) {
+				parquetTransaction, err := ProtoTransactionToParquet(block.Block.Transactions[i], block.TransactionReceipts[i])
+				if err != nil {
+					return nil, err
+				}
+				outputs = append(outputs, parquetTransaction)
+			}
+		}
+
+		filename := fmt.Sprintf("transactions/%s/%d.parquet", util.RangeName(blockNumber, d.config.DirectoryRange), blockNumber)
+
+		if err := d.store.innerStore.WriteMany(ctx, outputs, &model.ParquetTransaction{}, filename); err != nil {
+			return nil, err
+		}
+		d.logger.Infof("successfully parqueted transactions for %d", blockNumber)
+
+		return nil, nil
+	}
+}
+
+// parquetAndUploadLogs writes parquet to storage for logs
+func (d *Driver) parquetAndUploadLogs(res interface{}) pool.Runner {
+	return func(ctx context.Context) (interface{}, error) {
+		block, blockNumber, err := unpackBlock(res)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(block.Block.Transactions) == 0 {
+			return nil, nil
+		}
+
+		var outputs []interface{}
+		for _, receipt := range block.TransactionReceipts {
+			for _, log := range receipt.Logs {
+				outputs = append(outputs, ProtoLogToParquet(log))
+			}
+		}
+
+		filename := fmt.Sprintf("logs/%s/%d.parquet", util.RangeName(blockNumber, d.config.DirectoryRange), blockNumber)
+
+		if err := d.store.innerStore.WriteMany(ctx, outputs, &model.ParquetLog{}, filename); err != nil {
+			return nil, err
+		}
+		d.logger.Infof("successfully parqueted traces for %d", blockNumber)
+
+		return nil, nil
+	}
+}
+
+// parquetAndUploadTraces writes parquet to storage for traces
+func (d *Driver) parquetAndUploadTraces(res interface{}) pool.Runner {
+	return func(ctx context.Context) (interface{}, error) {
+		block, blockNumber, err := unpackBlock(res)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(block.Block.Transactions) == 0 || len(block.CallTraces) == 0 {
+			return nil, nil
+		}
+
+		//	Filter null=>null transactions and ensure transaction and trace counts match
+		filteredTx := filterNonTraceTransactions(block.Block.Transactions)
+		if len(filteredTx) != len(block.CallTraces) {
+			return nil, errors.Errorf("transactions and traces count don't match for block: %d %d != %d", blockNumber, len(filteredTx), len(block.CallTraces))
+		}
+
+		var bfsWG sync.WaitGroup
+		var outputs []interface{}
+		var transferOutputs []interface{}
+		mutex := sync.Mutex{}
+		for i, callTrace := range block.CallTraces {
+			bfsWG.Add(1)
+			go func(index int, callTrace *protos.CallTrace) {
+				defer bfsWG.Done()
+				for idx, transfer := range callTrace.Result.BeforeEVMTransfers {
+					transferOutputs = append(
+						transferOutputs,
+						ProtoEVMTransferToParquet(
+							transfer,
+							block.Block.Transactions[index],
+							hashCallTrace(callTrace),
+							"before",
+							int64(index),
+							int64(idx),
+						))
+				}
+				for idx, transfer := range callTrace.Result.AfterEVMTransfers {
+					transferOutputs = append(
+						transferOutputs,
+						ProtoEVMTransferToParquet(
+							transfer,
+							block.Block.Transactions[index],
+							hashCallTrace(callTrace),
+							"after",
+							int64(index),
+							int64(idx),
+						))
+				}
+				queue := make([]*callTraceNode, 0)
+				queue = append(
+					queue,
+					&callTraceNode{
+						CallTrace:  callTrace,
+						Index:      int64(index),
+						ParentHash: "",
+					},
+				)
+				for len(queue) > 0 {
+					currentNode := queue[0]
+					queue = queue[1:]
+					currCallTrace := currentNode.CallTrace
+					traceHash := hashCallTrace(currCallTrace)
+					mutex.Lock()
+					outputs = append(
+						outputs,
+						ProtoTraceToParquet(
+							callTrace,
+							block.Block.Transactions[index],
+							traceHash,
+							currentNode.ParentHash,
+							currentNode.Index,
+						),
+					)
+
+					mutex.Unlock()
+					for callIndex, call := range currentNode.CallTrace.Result.Calls {
+						queue = append(
+							queue,
+							&callTraceNode{
+								CallTrace:  &protos.CallTrace{Result: call},
+								Index:      int64(callIndex),
+								ParentHash: traceHash,
+							},
+						)
+					}
+
+				}
+			}(i, callTrace)
+		}
+		bfsWG.Wait()
+
+		filename := fmt.Sprintf("traces/%s/%d.parquet", util.RangeName(blockNumber, d.config.DirectoryRange), blockNumber)
+		if err := d.store.innerStore.WriteMany(ctx, outputs, &model.ParquetTrace{}, filename); err != nil {
+			return nil, err
+		}
+
+		d.logger.Infof("successfully parqueted logs for %d", blockNumber)
+
+		filename = fmt.Sprintf("transfers/%s/%d.parquet", util.RangeName(blockNumber, d.config.DirectoryRange), blockNumber)
+		if err := d.store.innerStore.WriteMany(ctx, transferOutputs, &model.ParquetEVMTransfer{}, filename); err != nil {
+			return nil, err
+		}
+
+		d.logger.Infof("successfully parqueted evm transfers for %d", blockNumber)
+
+		return nil, nil
+	}
+}
+
+// unpackBlock pulls a block out of the generic response from the accumulator
+func unpackBlock(res interface{}) (*protos.Data, uint64, error) {
+	obj, ok := res.(*protos.Data)
+	if !ok {
+		return nil, 0, errors.New("Result is not correct type")
+	}
+
+	hexBlockNumber := strings.Replace(obj.Block.Number, "0x", "", -1)
+	blockNumber, err := strconv.ParseInt(hexBlockNumber, 16, 64)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return obj, uint64(blockNumber), nil
+}
+
+func filterNonTraceTransactions(in []*protos.Transaction) []*protos.Transaction {
+	var filteredTransactions []*protos.Transaction
+	for _, tx := range in {
+		if tx.From != nullAddress || tx.To != nullAddress {
+			filteredTransactions = append(filteredTransactions, tx)
+		}
+	}
+	return filteredTransactions
+}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.20
 require (
 	cloud.google.com/go/storage v1.27.0
 	github.com/caarlos0/env/v7 v7.1.0
-	github.com/coherentopensource/chain-interactor v0.0.10-0.20230504195445-5910880ccb0c
-	github.com/coherentopensource/go-service-framework v0.0.14-0.20230526204416-c501c07400e3
+	github.com/coherentopensource/chain-interactor v0.0.10-0.20230602151837-4c7a42006f05
+	github.com/coherentopensource/go-service-framework v0.0.14-0.20230605204212-dabf9a164af6
 	github.com/pkg/errors v0.9.1
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20230312005205-fbbcdea5f512

--- a/go.sum
+++ b/go.sum
@@ -191,10 +191,14 @@ github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 h1:ytcWPaNPhNoG
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/coherentopensource/chain-interactor v0.0.10-0.20230504195445-5910880ccb0c h1:3TUSClw2/OSxEkGq4knCkESu2S5QbmHcxXcAIRJd2Nw=
 github.com/coherentopensource/chain-interactor v0.0.10-0.20230504195445-5910880ccb0c/go.mod h1:E15JDCpQroIVUGw4dGRnmlysDekujM5JE8VMGPapJAI=
+github.com/coherentopensource/chain-interactor v0.0.10-0.20230602151837-4c7a42006f05 h1:Mz7iNijx5n8aDsT1bIRJBY8CrmdnkKPTaD8brji1WD4=
+github.com/coherentopensource/chain-interactor v0.0.10-0.20230602151837-4c7a42006f05/go.mod h1:E15JDCpQroIVUGw4dGRnmlysDekujM5JE8VMGPapJAI=
 github.com/coherentopensource/go-service-framework v0.0.12 h1:5VNBtsfnivHmFunhZDJ3Y1Sqml/vDkEAnNxmsAOTlvI=
 github.com/coherentopensource/go-service-framework v0.0.12/go.mod h1:xuysXqWXP0+ncYlvtdSz1HgsWYmmJmDPWLWBcdh5Kvs=
 github.com/coherentopensource/go-service-framework v0.0.14-0.20230526204416-c501c07400e3 h1:s+xwcg4EdYT8x+64MhDtfseoiyt095e8xorYnc1P1CU=
 github.com/coherentopensource/go-service-framework v0.0.14-0.20230526204416-c501c07400e3/go.mod h1:nlJpXxb/YY1RQO2xOTCOy4zE9ptrubgDXk7vbx8EFns=
+github.com/coherentopensource/go-service-framework v0.0.14-0.20230605204212-dabf9a164af6 h1:hLXmaQmF4dKWg310ob+VaJWfmhGYMzHoDmdh3rmfTOo=
+github.com/coherentopensource/go-service-framework v0.0.14-0.20230605204212-dabf9a164af6/go.mod h1:nlJpXxb/YY1RQO2xOTCOy4zE9ptrubgDXk7vbx8EFns=
 github.com/colinmarc/hdfs/v2 v2.1.1/go.mod h1:M3x+k8UKKmxtFu++uAZ0OtDU8jR3jnaZIAc6yK4Ue0c=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/model/arbitrum/parquet.go
+++ b/model/arbitrum/parquet.go
@@ -1,0 +1,97 @@
+package arbitrum
+
+// ParquetBlock represents a block in parquet form
+type ParquetBlock struct {
+	Number           string   `parquet:"name=block_number, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Hash             string   `parquet:"name=block_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	ParentHash       string   `parquet:"name=parent_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Nonce            string   `parquet:"name=nonce, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	SHA3Uncles       string   `parquet:"name=sha3_uncles, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	LogsBloom        string   `parquet:"name=logs_bloom, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TransactionsRoot string   `parquet:"name=transactions_root, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	StateRoot        string   `parquet:"name=state_root, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	ReceiptsRoot     string   `parquet:"name=receipts_root, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Miner            string   `parquet:"name=miner, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Difficulty       string   `parquet:"name=difficulty, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TotalDifficulty  string   `parquet:"name=total_difficulty, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	ExtraData        string   `parquet:"name=extra_data, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Size             string   `parquet:"name=size, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	GasLimit         string   `parquet:"name=gas_limit, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	GasUsed          string   `parquet:"name=gas_used, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Timestamp        string   `parquet:"name=timestamp, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Uncles           []string `parquet:"name=uncles, type=MAP, convertedtype=LIST, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`
+	MixHash          string   `parquet:"name=mix_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+}
+
+// ParquetTransaction represents a transaction in parquet form
+type ParquetTransaction struct {
+	BlockHash         string `parquet:"name=block_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	BlockNumber       string `parquet:"name=block_number, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	From              string `parquet:"name=from_address, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Gas               string `parquet:"name=gas, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	GasPrice          string `parquet:"name=gas_price, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Hash              string `parquet:"name=transaction_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Input             string `parquet:"name=input, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Nonce             string `parquet:"name=nonce, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	To                string `parquet:"name=to_address, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TransactionIndex  string `parquet:"name=transaction_index, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Value             string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	V                 string `parquet:"name=v, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	R                 string `parquet:"name=r, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	S                 string `parquet:"name=s, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	CumulativeGasUsed string `parquet:"name=cumulative_gas_used, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	GasUsed           string `parquet:"name=gas_used, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	LogsBloom         string `parquet:"name=logs_bloom, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Root              string `parquet:"name=root, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Status            string `parquet:"name=status, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	L1TxOrigin        string `parquet:"name=l1_tx_origin, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	L1Fee             string `parquet:"name=l1_fee, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	L1FeeScalar       string `parquet:"name=l1_fee_scalar, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	L1GasPrice        string `parquet:"name=l1_gas_price, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	L1GasUsed         string `parquet:"name=l1_gas_used, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+}
+
+// ParquetLog represents a log in parquet form
+type ParquetLog struct {
+	BlockNumber      string   `parquet:"name=block_number, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	BlockHash        string   `parquet:"name=block_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TransactionHash  string   `parquet:"name=transaction_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TransactionIndex string   `parquet:"name=transaction_index, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	LogIndex         string   `parquet:"name=log_index, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Address          string   `parquet:"name=address, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Data             string   `parquet:"name=data, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Topics           []string `parquet:"name=topics, type=MAP, convertedtype=LIST, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`
+	Removed          bool     `parquet:"name=removed, type=BOOLEAN"`
+}
+
+// ParquetTrace represents a trace in parquet form
+type ParquetTrace struct {
+	BlockNumber     string `parquet:"name=block_number, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	BlockHash       string `parquet:"name=block_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TransactionHash string `parquet:"name=transaction_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Hash            string `parquet:"name=trace_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	ParentHash      string `parquet:"name=parent_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Index           int64  `parquet:"name=trace_index, type=INT64"`
+	Type            string `parquet:"name=type, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	From            string `parquet:"name=from_address, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	To              string `parquet:"name=to_address, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Value           string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Gas             string `parquet:"name=gas, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	GasUsed         string `parquet:"name=gas_used, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Input           string `parquet:"name=input, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Output          string `parquet:"name=output, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+}
+
+type ParquetEVMTransfer struct {
+	BlockNumber      string `parquet:"name=block_number, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	BlockHash        string `parquet:"name=block_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TransactionHash  string `parquet:"name=transaction_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TraceHash        string `parquet:"name=trace_hash, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Purpose          string `parquet:"name=purpose, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	From             string `parquet:"name=from_address, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	To               string `parquet:"name=to_address, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Value            string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Sequence         string `parquet:"name=sequence, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TransactionIndex int64  `parquet:"name=transaction_index, type=INT64"`
+	Index            int64  `parquet:"name=transfer_index, type=INT64"`
+}


### PR DESCRIPTION
note:
- arbitrum traces include `EVMTransfers` per transaction, however since this is embedded within a trace structure, I added a logic to transform them to parquets and the writer to `traces` will also write to `transfers` -> need a new table for Arbitrum: `EVMTransfers`
- arbitrum also doesn't have a rpc method for `ethgetBlockReceipts`, so it is using the same logic as `Optimism` and `Base`